### PR TITLE
Upgrade starters to Edgware.SR2

### DIFF
--- a/spring-cloud-services-dependencies-parent/pom.xml
+++ b/spring-cloud-services-dependencies-parent/pom.xml
@@ -37,7 +37,7 @@
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
 		<spring-boot.version>1.5.9.RELEASE</spring-boot.version>
-		<spring-cloud.version>Edgware.SR1</spring-cloud.version>
+		<spring-cloud.version>Edgware.SR2</spring-cloud.version>
 	</properties>
 	
 	<dependencyManagement>


### PR DESCRIPTION
Tested this locally and got a clean run of the ATs on `coral`.

[#155092207]