### PR TITLE
Update to spring-security-oauth2 >= 2.3.4

### DIFF
--- a/spring-cloud-services-dependencies/pom.xml
+++ b/spring-cloud-services-dependencies/pom.xml
@@ -38,7 +38,7 @@
 		<main.basedir>${basedir}/../..</main.basedir>
 		<spring-cloud-services-connectors.version>2.0.3.BUILD-SNAPSHOT</spring-cloud-services-connectors.version>
 		<cloudfoundry-certificate-truster.version>1.0.1.RELEASE</cloudfoundry-certificate-truster.version>
-		<spring-security-oauth2.version>2.3.3.RELEASE</spring-security-oauth2.version>
+		<spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
closes pivotal-cf/spring-cloud-services-starters#53