### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,15 @@
 	<packaging>pom</packaging>
 	<name>spring-cloud-services-starter-build</name>
 	<description>Spring Cloud Services Starter Build</description>
-	<url>http://projects.spring.io/spring-cloud/</url>
+	<url>https://projects.spring.io/spring-cloud/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 		</license>
 	</licenses>
 	<scm>
@@ -31,7 +31,7 @@
 			<name>Roy Clarkson</name>
 			<email>rclarkson@pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 		</developer>
 	</developers>
 	<properties>

--- a/spring-cloud-services-dependencies-parent/pom.xml
+++ b/spring-cloud-services-dependencies-parent/pom.xml
@@ -7,15 +7,15 @@
 	<name>spring-cloud-services-dependencies-parent</name>
 	<description>Spring Cloud Services Dependencies Parent</description>
 	<packaging>pom</packaging>
-	<url>http://projects.spring.io/spring-cloud</url>
+	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 		</license>
 	</licenses>
 	<scm>
@@ -31,7 +31,7 @@
 			<name>Roy Clarkson</name>
 			<email>rclarkson@pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 		</developer>
 	</developers>
 	<properties>

--- a/spring-cloud-services-dependencies/pom.xml
+++ b/spring-cloud-services-dependencies/pom.xml
@@ -7,15 +7,15 @@
 	<name>spring-cloud-services-dependencies</name>
 	<description>Spring Cloud Services Dependencies</description>
 	<packaging>pom</packaging>
-	<url>http://projects.spring.io/spring-cloud</url>
+	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 		</license>
 	</licenses>
 	<scm>
@@ -31,7 +31,7 @@
 			<name>Roy Clarkson</name>
 			<email>rclarkson@pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 		</developer>
 	</developers>
 	<properties>

--- a/spring-cloud-services-starter-circuit-breaker/pom.xml
+++ b/spring-cloud-services-starter-circuit-breaker/pom.xml
@@ -10,10 +10,10 @@
 	<artifactId>spring-cloud-services-starter-circuit-breaker</artifactId>
 	<name>spring-cloud-services-starter-circuit-breaker</name>
 	<description>Spring Cloud Services Starter</description>
-	<url>http://projects.spring.io/spring-cloud</url>
+	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.pivotal.io</url>
+		<url>https://www.pivotal.io</url>
 	</organization>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>

--- a/spring-cloud-services-starter-config-client/pom.xml
+++ b/spring-cloud-services-starter-config-client/pom.xml
@@ -10,10 +10,10 @@
 	<artifactId>spring-cloud-services-starter-config-client</artifactId>
 	<name>spring-cloud-services-starter-config-client</name>
 	<description>Spring Cloud Services Starter</description>
-	<url>http://projects.spring.io/spring-cloud</url>
+	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.pivotal.io</url>
+		<url>https://www.pivotal.io</url>
 	</organization>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>

--- a/spring-cloud-services-starter-service-registry/pom.xml
+++ b/spring-cloud-services-starter-service-registry/pom.xml
@@ -10,10 +10,10 @@
 	<artifactId>spring-cloud-services-starter-service-registry</artifactId>
 	<name>spring-cloud-services-starter-service-registry</name>
 	<description>Spring Cloud Services Starter</description>
-	<url>http://projects.spring.io/spring-cloud</url>
+	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.pivotal.io</url>
+		<url>https://www.pivotal.io</url>
 	</organization>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projects.spring.io/spring-cloud/ migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://projects.spring.io/spring-cloud migrated to:  
  https://projects.spring.io/spring-cloud ([https](https://projects.spring.io/spring-cloud) result 301).
* http://www.pivotal.io migrated to:  
  https://www.pivotal.io ([https](https://www.pivotal.io) result 301).
* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance