### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Spring Cloud Services Starters image:https://build.spring.io/plugins/servlet/buildStatusImage/CLOUD-SCSSTART["Build Status", link="https://build.spring.io/browse/CLOUD-SCSSTART"]
 
-Spring Cloud Services Starters are a curated set of dependencies for use with link:http://docs.pivotal.io/spring-cloud-services/index.html[Spring Cloud Services] in a link:http://pivotal.io/platform[Pivotal Cloud Foundry] environment.
+Spring Cloud Services Starters are a curated set of dependencies for use with link:https://docs.pivotal.io/spring-cloud-services/index.html[Spring Cloud Services] in a link:https://pivotal.io/platform[Pivotal Cloud Foundry] environment.
 
 :toc:
 :toc-placement!:
@@ -34,7 +34,7 @@ Include the BOM and starter dependencies in your project using Maven or Gradle.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.demo</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://pivotal.io/platform with 1 occurrences migrated to:  
  https://pivotal.io/platform ([https](https://pivotal.io/platform) result 200).
* [ ] http://docs.pivotal.io/spring-cloud-services/index.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/index.html ([https](https://docs.pivotal.io/spring-cloud-services/index.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences