### PR TITLE
Fix RestTemplate bean name

### DIFF
--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
@@ -83,8 +83,7 @@ public class VaultTokenRenewalAutoConfiguration {
 		return new VaultTokenRefresher(restTemplate, obscuredToken, renewTTL, refreshUri, request);
 	}
 
-	@Qualifier("vaultTokenRenewal")
-	@Bean
+	@Bean("vaultTokenRenewal")
 	public RestTemplate restTemplate() {
 		return new RestTemplate();
 	}


### PR DESCRIPTION
Using `@Qualifier` on an `@Bean` annotated method doesn't register 
the bean under the value of `@Qualifier` annotation.

resolves #134