### PR TITLE
leave sensitive information in debug

### DIFF
--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
@@ -120,7 +120,7 @@ public class VaultTokenRenewalAutoConfiguration {
 				LOGGER.debug("Renewing Vault token " + obscuredToken + " for " + renewTTL + " milliseconds.");
 				restTemplate.postForObject(refreshUri, request, String.class);
 			} catch (RestClientException e) {
-				LOGGER.error("Unable to renew Vault token. Is the token invalid or expired?");
+				LOGGER.error("Unable to renew Vault token " + obscuredToken + ". Is the token invalid or expired?");
 			}
 		}
 	}

--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
@@ -117,7 +117,7 @@ public class VaultTokenRenewalAutoConfiguration {
 		@Scheduled(fixedRateString="${vault.token.renew.rate:60000}")  // <-- Default to renew token every 60 seconds
 		public void refreshVaultToken() {
 			try {
-				LOGGER.debug("Renewing Vault token for " + obscuredToken + " for " + renewTTL + " milliseconds.");
+				LOGGER.debug("Renewing Vault token " + obscuredToken + " for " + renewTTL + " milliseconds.");
 				restTemplate.postForObject(refreshUri, request, String.class);
 			} catch (RestClientException e) {
 				LOGGER.error("Unable to renew Vault token. Is the token invalid or expired?");

--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
@@ -117,10 +117,11 @@ public class VaultTokenRenewalAutoConfiguration {
 		@Scheduled(fixedRateString="${vault.token.renew.rate:60000}")  // <-- Default to renew token every 60 seconds
 		public void refreshVaultToken() {
 			try {
-				LOGGER.info("Renewing Vault token " + obscuredToken + " for " + renewTTL + " milliseconds.");
+				LOGGER.debug("Vault token={}", obscuredToken);
+				LOGGER.info("Renewing Vault token for " + renewTTL + " milliseconds.");
 				restTemplate.postForObject(refreshUri, request, String.class);
 			} catch (RestClientException e) {
-				LOGGER.error("Unable to renew Vault token " + obscuredToken + ". Is the token invalid or expired?");
+				LOGGER.error("Unable to renew Vault token. Is the token invalid or expired?");
 			}
 		}
 	}

--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/VaultTokenRenewalAutoConfiguration.java
@@ -117,8 +117,7 @@ public class VaultTokenRenewalAutoConfiguration {
 		@Scheduled(fixedRateString="${vault.token.renew.rate:60000}")  // <-- Default to renew token every 60 seconds
 		public void refreshVaultToken() {
 			try {
-				LOGGER.debug("Vault token={}", obscuredToken);
-				LOGGER.info("Renewing Vault token for " + renewTTL + " milliseconds.");
+				LOGGER.debug("Renewing Vault token for " + obscuredToken + " for " + renewTTL + " milliseconds.");
 				restTemplate.postForObject(refreshUri, request, String.class);
 			} catch (RestClientException e) {
 				LOGGER.error("Unable to renew Vault token. Is the token invalid or expired?");


### PR DESCRIPTION
Even obscured token doesn't mask short strings well. To avoid overcomplicated masking logic for a feature I seldom think people need, just leaving this as a debug log.