### PR TITLE
Revert auto release commit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.3.1-SNAPSHOT
+version=3.3.0-SNAPSHOT
 parallel=true


### PR DESCRIPTION
Current pipeline automatically commits version bump to main, but now GH default branches don't accept force-push to fix history.

I am reverting the change and changing the pipeline so changes are stored in a branch like in java-cfenv.