### PR TITLE
Adds oauth2 properties which will be used by ConfigResourceClient and ConfigServicePropertySourceLocator

### DIFF
--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/ConfigClientEnvironmentPostProcessor.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/ConfigClientEnvironmentPostProcessor.java
@@ -15,21 +15,19 @@
  */
 package io.pivotal.spring.cloud.config.client;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.pivotal.cfenv.core.CfCredentials;
+import io.pivotal.cfenv.core.CfEnv;
+import io.pivotal.cfenv.core.CfService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
-
-import io.pivotal.cfenv.core.CfCredentials;
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
 
 /**
  * Using {@link CfEnv} directly here as we need to set the
@@ -51,15 +49,33 @@ public class ConfigClientEnvironmentPostProcessor implements EnvironmentPostProc
 		if (configServices.size() != 1)
 			return;
 		CfCredentials credentials = configServices.stream().findFirst().get().getCredentials();
-		Map<String, Object> map = new HashMap<>();
-		map.put("spring.config.import", "optional:configserver:" + credentials.getUri());
-		map.put("spring.cloud.refresh.additional-property-sources-to-retain", SPRING_CLOUD_SERVICES_CONFIG_IMPORT);
-		environment.getPropertySources().addFirst(new MapPropertySource(SPRING_CLOUD_SERVICES_CONFIG_IMPORT, map));
+		environment.getPropertySources().addFirst(oauth2PropertySource(credentials));
+		environment.getPropertySources().addFirst(configImportPropertySource(credentials));
 	}
 
 	@Override
 	public int getOrder() {
 		return ConfigDataEnvironmentPostProcessor.ORDER - 1;
+	}
+
+	private MapPropertySource configImportPropertySource(CfCredentials credentials) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("spring.config.import", "optional:configserver:" + credentials.getUri());
+		map.put("spring.cloud.refresh.additional-property-sources-to-retain", SPRING_CLOUD_SERVICES_CONFIG_IMPORT);
+		return new MapPropertySource(SPRING_CLOUD_SERVICES_CONFIG_IMPORT, map);
+	}
+
+	/**
+	 * This method can be removed once java-cfenv supports config-client.
+	 */
+	private MapPropertySource oauth2PropertySource(CfCredentials credentials) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("spring.cloud.config.uri", credentials.getUri());
+		map.put("spring.cloud.config.client.oauth2.client-id", credentials.getString("client_id"));
+		map.put("spring.cloud.config.client.oauth2.client-secret", credentials.getString("client_secret"));
+		map.put("spring.cloud.config.client.oauth2.access-token-uri", credentials.getString("access_token_uri"));
+
+		return new MapPropertySource("CfConfigClientProcessor", map);
 	}
 
 }

--- a/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/ConfigClientOAuth2BootstrapConfiguration.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/java/io/pivotal/spring/cloud/config/client/ConfigClientOAuth2BootstrapConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.config.client;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ ConfigClientProperties.class })
+@EnableConfigurationProperties(ConfigClientOAuth2Properties.class)
+public class ConfigClientOAuth2BootstrapConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(ConfigServicePropertySourceLocator.class)
+	@ConditionalOnProperty(prefix = "spring.cloud.config.client.oauth2",
+			name = { "client-id", "client-secret", "access-token-uri" })
+	public ConfigServicePropertySourceLocator configServicePropertySourceLocator(
+			ConfigClientProperties configClientProperties, ConfigClientOAuth2Properties configClientOAuth2Properties) {
+		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("config-client")
+				.clientId(configClientOAuth2Properties.getClientId())
+				.clientSecret(configClientOAuth2Properties.getClientSecret())
+				.tokenUri(configClientOAuth2Properties.getAccessTokenUri())
+				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS).build();
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.getInterceptors().add(new OAuth2AuthorizedClientHttpRequestInterceptor(clientRegistration));
+
+		ConfigServicePropertySourceLocator configServicePropertySourceLocator = new ConfigServicePropertySourceLocator(
+				configClientProperties);
+		configServicePropertySourceLocator.setRestTemplate(restTemplate);
+		return configServicePropertySourceLocator;
+	}
+
+}

--- a/spring-cloud-services-config-client-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-services-config-client-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -5,6 +5,9 @@ io.pivotal.spring.cloud.config.client.ConfigResourceClientAutoConfiguration
 org.springframework.boot.BootstrapRegistryInitializer=\
 io.pivotal.spring.cloud.config.client.ConfigClientOAuth2BootstrapRegistryInitializer
 
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+io.pivotal.spring.cloud.config.client.ConfigClientOAuth2BootstrapConfiguration
+
 org.springframework.boot.env.EnvironmentPostProcessor=\
 io.pivotal.spring.cloud.config.client.PropertyMaskingEnvironmentPostProcessor,\
 io.pivotal.spring.cloud.config.client.ConfigClientEnvironmentPostProcessor

--- a/spring-cloud-services-config-client-autoconfigure/src/test/java/io/pivotal/spring/cloud/config/client/ConfigClientAutoConfigResourceTest.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/test/java/io/pivotal/spring/cloud/config/client/ConfigClientAutoConfigResourceTest.java
@@ -22,7 +22,6 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.cloud.config.client.ConfigClientAutoConfiguration;
 import org.springframework.cloud.config.client.ConfigClientProperties;
-import org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -37,7 +36,7 @@ public class ConfigClientAutoConfigResourceTest {
 					.of(ConfigResourceClientAutoConfiguration.class, ConfigClientAutoConfiguration.class));
 
 	@Test
-	public void plainTextConfigClientIsNotCreated() throws Exception {
+	public void plainTextConfigClientIsNotCreated() {
 		this.contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(ConfigClientProperties.class);
 			assertThat(context).doesNotHaveBean(PlainTextConfigClient.class);
@@ -45,7 +44,7 @@ public class ConfigClientAutoConfigResourceTest {
 	}
 
 	@Test
-	public void plainTextConfigClientIsCreated() throws Exception {
+	public void plainTextConfigClientIsCreated() {
 		this.contextRunner.withPropertyValues("spring.cloud.config.client.oauth2.client-id=acme",
 				"spring.cloud.config.client.oauth2.client-secret=acmesecret",
 				"spring.cloud.config.client.oauth2.access-token-uri=acmetokenuri").run(context -> {

--- a/spring-cloud-services-config-client-autoconfigure/src/test/java/io/pivotal/spring/cloud/config/client/OAuth2ConfigResourceClientTest.java
+++ b/spring-cloud-services-config-client-autoconfigure/src/test/java/io/pivotal/spring/cloud/config/client/OAuth2ConfigResourceClientTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.core.io.Resource;
 import org.springframework.mock.env.MockEnvironment;


### PR DESCRIPTION
oauth2 properties for service-registry are provided by java-cfenv but this is not the case for config-server. 
I've created this[ pull-request](https://github.com/pivotal-cf/java-cfenv/pull/198) in java-cfenv repository but in the meantime we can need to provide those properties in the library. 
Closes #321 

Also we needed to inject a custom `RestTemplate` with oauth2 authorization support to `ConfigServicePropertySourceLocator`. this bean is used when legacy bootstrap is enabled. 
Closes #322 
Closes #319 
