### PR TITLE
Bump boot cloud versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 version=3.5.5-SNAPSHOT
 parallel=true
 
-springCloudVersion=2021.0.5
-springBootVersion=2.7.8
+springCloudVersion=2021.0.6
+springBootVersion=2.7.9
 springFrameworkVersion=5.3.25
 cloudfoundryCertificateTrusterVersion=1.0.1.RELEASE
 javaCfenvVersion=2.4.1


### PR DESCRIPTION
Updated Spring Boot to 2.7.9 and Spring Cloud to 2021.0.6