### PR TITLE
Upgrade java-cfenv

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ parallel=true
 
 springCloudVersion=2023.0.0
 springBootVersion=3.2.0
-javaCfenvVersion=3.1.3
+javaCfenvVersion=3.1.5
 nohttpVersion=0.0.11
 wireMockVersion=3.3.1


### PR DESCRIPTION
* between java-cfenv 3.1.3 and 3.1.5, one of its dependencies, `json-io` was upgraded to fix a CVE
* some users have started overriding spring-cloud-services-starters transitive dependencies to remove the CVE, see https://github.com/cloudfoundry/java-buildpack/issues/1062#issuecomment-1989218776