### PR TITLE
ci: decrease polling frequency for git resources to 10m

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -232,6 +232,7 @@ resources:
   - name: src
     type: git
     icon: github
+    check_every: 10m
     source:
       uri: https://((github.token))@github.com/pivotal-cf/spring-cloud-services-starters.git
       branch: ((branch))
@@ -241,6 +242,7 @@ resources:
   - name: staging-src
     type: git
     icon: github
+    check_every: 10m
     source:
       uri: https://((github.token))@github.com/pivotal-cf/spring-cloud-services-starters.git
       branch: ((github.git-email))/staging-((branch))
@@ -248,6 +250,7 @@ resources:
   - name: ci-images-src
     type: git
     icon: github
+    check_every: 10m
     source:
       uri: https://((github.token))@github.com/pivotal-cf/spring-cloud-services-starters.git
       branch: ((branch))


### PR DESCRIPTION
## Summary
- Added `check_every: 10m` to all definitions of git resources in `ci/pipeline.yml` to reduce the polling load on Concourse.

## Test plan
- Validated Concourse pipeline configuration locally using:
  ```bash
  fly validate-pipeline --config ci/pipeline.yml
  ```

Made with [Cursor](https://cursor.com)