### PR TITLE
ci: decrease polling frequency for git resources to 10m

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -176,6 +176,7 @@ resources:
   - name: src
     type: git
     icon: github
+    check_every: 10m
     source:
       uri: https://((github.token))@github.com/pivotal-cf/spring-cloud-services-starters.git
       branch: ((branch))
@@ -185,6 +186,7 @@ resources:
   - name: staging-src
     type: git
     icon: github
+    check_every: 10m
     source:
       uri: https://((github.token))@github.com/pivotal-cf/spring-cloud-services-starters.git
       branch: ((github.git-email))/staging-((branch))


### PR DESCRIPTION
## Summary
- Added `check_every: 10m` to all definitions of git resources in `ci/pipeline.yml` to reduce the polling load on Concourse.

## Test plan
- Validated Concourse pipeline configuration locally using:
  ```bash
  fly validate-pipeline --config ci/pipeline.yml
  ```

Made with [Cursor](https://cursor.com)